### PR TITLE
refacto: remove conc tags on tasks

### DIFF
--- a/backend/src/repositories/orchestration/tasks/retry.py
+++ b/backend/src/repositories/orchestration/tasks/retry.py
@@ -51,6 +51,9 @@ def is_extraction_task_retriable(
                 f"Task '{task.name}' will be retried due to exception {type(e).__name__}"
             )
             return True
+        elif isinstance(e, TimeoutError):
+            logger.warning(f"Timeout error on task '{task.name}' will be retried")
+            return True
         else:
             logger.error(
                 f"Task '{task.name}' will NOT be retried due to exception '{type(e).__name__}'"

--- a/backend/src/repositories/orchestration/tasks/task_html_parsing.py
+++ b/backend/src/repositories/orchestration/tasks/task_html_parsing.py
@@ -176,7 +176,6 @@ def do_analysis(
 
 @task(
     task_run_name="html-to-entity-{content_id}",
-    tags=["heavy"],  # mark as heavy task
     log_prints=False,
 )
 def execute_task(

--- a/backend/start-server.sh
+++ b/backend/start-server.sh
@@ -25,8 +25,8 @@ prefect gcl create api-rate-limiting --limit 10 --slot-decay-per-second 2.0
 # *********************************
 # heavy tasks limit (e.g., extractors)
 # *********************************
-prefect --no-prompt concurrency-limit delete heavy  # in case it already exists
-prefect concurrency-limit create heavy 10 
+# prefect --no-prompt concurrency-limit delete heavy  # in case it already exists
+# prefect concurrency-limit create heavy 10 
 
 
 # *********************************


### PR DESCRIPTION
concurrency is globally managed, tasks concurrency may interfere with global one, creating bottlenecks